### PR TITLE
Altera classe das páginas na home

### DIFF
--- a/themes/apyb/templates/home.html
+++ b/themes/apyb/templates/home.html
@@ -4,7 +4,7 @@
   <div class="row">
     {% for page in pages|sort(attribute='sortorder') %}
       {% if page.slug != 'index' %}
-        <div class="col-xs-4 page-description">
+        <div class="col-xs-12 col-md-4 col-lg-4 page-description">
           <h1>{{ page.title }}</h1>
 
           <div class="page-description-text">


### PR DESCRIPTION
Adiciona as classes `col-md-4` e `col-lg-4` e altera a classe `col-xs-4` para `col-xs-12` corrigindo a quebra de texto em navegadores com baixa resolução.

![melhoria-acomodacao-paginas](https://cloud.githubusercontent.com/assets/353311/11532661/6cc6e426-98ec-11e5-93fa-8defcdd66289.png)
