### PR TITLE
google analytics e webmasters-tools

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -24,6 +24,13 @@ GITHUB_BRANCH = 'pelican'
 # Referencia ao Google Groups
 GOOGLE_GROUPS_MAIL_LIST_NAME = 'python-brasil'
 
+# GOOGLE_ANALYTICS
+GOOGLE_ANALYTICS_CODE = None
+
+# https://www.google.com/webmasters/tools/
+# https://support.google.com/webmasters/answer/35659?hl=pt&ref_topic=4564314
+GOOGLE_SITE_VERIFICATION_METATAG_CODE = None
+
 # Imagens
 ARTICLE_BANNERS_FOLDER = 'images/banners'
 

--- a/themes/apyb/templates/base.html
+++ b/themes/apyb/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-br">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -24,6 +24,11 @@
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    {% block head_js %}{% endblock %}
+
+    {% include 'google_tools.html' %}
+
   </head>
 
   <body>

--- a/themes/apyb/templates/google_tools.html
+++ b/themes/apyb/templates/google_tools.html
@@ -1,0 +1,18 @@
+{% if GOOGLE_ANALYTICS_CODE %}
+    <script>
+
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ GOOGLE_ANALYTICS_CODE }}', 'auto');
+    ga('require', 'linkid');
+    ga('send', 'pageview');
+
+
+    </script>
+{% endif %}
+{% if GOOGLE_SITE_VERIFICATION_METATAG_CODE %}
+    <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION_METATAG_CODE }}" />
+{% endif %}


### PR DESCRIPTION
preparação inicial para utilização do google analytics e webmasters-tools.
Os dois necessitam de intervenção manual de alguém com permissão no Google Analytics  e no webmasters-tools da Apyb para obter os códigos de acompanhamento.

Caso não consiga ninguém essa permissão, pode-se criar uma nova conta e depois dar permissão de administração para quem for necessario.
