### PR TITLE
Adiciona styling para o Dropdown

### DIFF
--- a/themes/apyb/static/apyb/css/base.css
+++ b/themes/apyb/static/apyb/css/base.css
@@ -62,7 +62,8 @@ header {
   display: inline-block;
 }
 
-.navbar-apyb .navbar-nav>li>a {
+.navbar-apyb .navbar-nav>li>a,
+.navbar-apyb .dropdown-menu>li>a {
   color: #ffffff;
 }
 
@@ -75,13 +76,21 @@ header {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF696969', endColorstr='#FF555555', gradientType=0);
 }
 
-.navbar-apyb .navbar-nav>li>a:hover {
+.navbar-apyb .navbar-nav>li>a:hover,
+.navbar-apyb .dropdown-menu > li > a:focus,
+.dropdown-menu > li > a:hover {
   /* gradient */
   background-color: #585858;
   background-image: -moz-linear-gradient(#727272 30%, #585858 95%);
   background-image: -webkit-linear-gradient(#727272 30%, #585858 95%);
   background-image: linear-gradient(#727272 30%, #585858 95%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF727272', endColorstr='#FF585858', gradientType=0);
+}
+
+.navbar-apyb .navbar-nav>.open>a,
+.navbar-apyb .navbar-nav>.open>a:focus,
+.navbar-apyb .navbar-nav>.open>a:hover {
+  background-color: #585858;
 }
 
 main {


### PR DESCRIPTION
Adiciona cor de fundo e de fonte para o dropdown na navbar, além de cores de fundo para eventos como hover e focus. Também corrige a cor de fundo do item da navbar quando este é "aberto".

![apyb-navbar-dropdown](https://cloud.githubusercontent.com/assets/353311/11543156/3d4ecd04-9922-11e5-8d27-f9873dacd764.png)
