### PR TITLE
Segmenta Grupo PyBR das Comunidades Locais

### DIFF
--- a/content/pages/eventos.md
+++ b/content/pages/eventos.md
@@ -1,6 +1,6 @@
 Title: Eventos
 Slug: eventos
 Template: page
-Sortorder: 4
+Sortorder: 5
 
 Página para a divulgação dos eventos da comunidade.

--- a/content/pages/grupos-de-usuarios.md
+++ b/content/pages/grupos-de-usuarios.md
@@ -1,7 +1,7 @@
-Title: Comunidade
-Slug: comunidade
-Template: comunidade
-Sortorder: 3
+Title: Comunidades Locais
+Slug: grupos-de-usuarios
+Template: page
+Sortorder: 4
 
 Conheça os grupos de usuários de Python espalhados pelo Brasil.
 

--- a/content/pages/patrocinio.md
+++ b/content/pages/patrocinio.md
@@ -1,6 +1,6 @@
 Title: Patrocinio
 Slug: patrocinio
 Template: page
-Sortorder: 6
+Sortorder: 7
 
 Página reservada para o branding dos patrocinadores da APyB.

--- a/content/pages/python-brasil.md
+++ b/content/pages/python-brasil.md
@@ -1,6 +1,6 @@
 Title: Python Brasil
 Slug: python-brasil
 Template: page
-Sortorder: 5
+Sortorder: 6
 
 Página para divulgar a Python Brasil

--- a/themes/apyb/templates/base.html
+++ b/themes/apyb/templates/base.html
@@ -53,9 +53,22 @@
                     {% endif %}
 
                     {% for link in NAVBAR_HOME_LINKS %}
-                      <li {% if href == link.href %}class="active"{% endif %}>
-                        <a href="{{ SITEURL }}/{{ link.href }}">{{ link.title }}</a>
-                      </li>
+                      {% if 'children' in link %}
+                        <li class="dropdown">
+                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            {{ link.title }} <span class="caret"></span>
+                          </a>
+                          <ul class="dropdown-menu navbar-apyb">
+                            {% for sublink in link.children %}
+                              <li><a href="{{ sublink.href }}">{{ sublink.title }}</a></li>
+                            {% endfor %}
+                          </ul>
+                        </li>
+                      {% else %}
+                        <li {% if href == link.href %}class="active"{% endif %}>
+                          <a href="{{ SITEURL }}/{{ link.href }}">{{ link.title }}</a>
+                        </li>
+                      {% endif %}
                     {% endfor %}
                   </ul>
                 </div>

--- a/themes/apyb/templates/comunidade-google-group.html
+++ b/themes/apyb/templates/comunidade-google-group.html
@@ -16,8 +16,6 @@
     <div class="col-xs-12">
       <hr>
 
-      <h3>Python Brasil no Google Groups</h3>
-
       <div id="google-groups-section" class="hide-google-groups">
         <iframe id="forum_embed" class="center-block" frameborder="0" scrolling="no" width="100%" height="700"></iframe>
       </div>


### PR DESCRIPTION
Possibilita a utilização de dropdown nos menus da navbar e separa os grupos de usuários (comunidades locais) do grupo principal da Python Brasil no Google Groups.

Sem screenshots dessa vez!
