### PR TITLE
Incluido libjpeg-dev no requirements.apt

### DIFF
--- a/requirements.apt
+++ b/requirements.apt
@@ -2,4 +2,6 @@
 python-dev
 libxslt1-dev
 libxml2-dev
+libjpeg-dev
+
 


### PR DESCRIPTION
Foi necessário instalar a biblioteca libjpeg-dev com o apt-get no ubuntu para que o pip conseguisse instalar o pillow.
E a mesma não se encontrava no requirements.apt
Após essa alteração os seguintes comandos devem funcionar sem erros e instalar todas as dependências do projeto.

``` shell
sudo ./install_os_dependencies.sh install
pip install -r requirements.txt
```
