### PR TITLE
Corrige links quebrados na nav-bar

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,11 +58,11 @@ NAVBAR_HOME_LINKS = [
         'children': [
             {
                 'title': 'Python Brasil Group',
-                'href': '/python-brasil-group',
+                'href': 'python-brasil-group',
             },
             {
                 'title': 'Comunidades Locais',
-                'href': '/comunidades-locais',
+                'href': 'comunidades-locais',
             },
         ]
     },

--- a/themes/apyb/templates/base.html
+++ b/themes/apyb/templates/base.html
@@ -60,7 +60,7 @@
                           </a>
                           <ul class="dropdown-menu navbar-apyb">
                             {% for sublink in link.children %}
-                              <li><a href="{{ sublink.href }}">{{ sublink.title }}</a></li>
+                              <li><a href="{{ SITEURL  }}/{{ sublink.href }}">{{ sublink.title }}</a></li>
                             {% endfor %}
                           </ul>
                         </li>


### PR DESCRIPTION
Adicionar `{{ SITEURL }}` e remove a barra no início dos links para formar os links corretamente.
