### PR TITLE
Incluída página sobre o prêmio Dorneles Treméa.

### DIFF
--- a/content/pages/premio-dorneles-tremea.md
+++ b/content/pages/premio-dorneles-tremea.md
@@ -1,0 +1,67 @@
+Title: Prêmio Dorneles Treméa
+Slug: premio-dorneles-tremea
+Template: page
+Sortorder: 8
+
+**O Prêmio Dorneles Treméa é concedido anualmente ao membro, ou membros, da comunidade Python brasileira que mantém vivo o espírito de colaboração, empreendedorismo e entrega à comunidade.**
+
+## O Prêmio
+Criado em 2011 pela Associação Python Brasil, o Prêmio Dorneles Treméa é um momento para a comunidade Python brasileira lembrar e homenagear as pessoas que mais se destacaram e contribuíram para manter vivo o espírito de colaboração, empreendedorismo e entrega à comunidade que eram características marcantes de Dorneles Treméa.
+
+### Critérios utilizados
+O prêmio é dedicado àquelas que, durante os últimos doze meses, dedicaram-se a:
+
+- Divulgar e ensinar Python
+- Participar ativamente das comunidades locais
+- Participar ativamente das comunidades online
+
+E estão excluídos da seleção:
+
+- Presidente da gestão atual da APyB
+- Big Kahuna e organizadores da Python Brasil
+- Homenageados em anos anteriores
+
+### Cerimônia de entrega
+A entrega do Prêmio Dorneles Treméa é realizada anualmente durante a PythonBrasil.
+
+## Homenageados
+
+**2011 - PythonBrasil[7] (São Paulo)**
+
+  * Luciano Ramalho
+  * Rodrigo Senra
+
+**2012 - PythonBrasil[8] (Rio de Janeiro)**
+
+  * Érico Andrei
+  * Marcel Caraciolo
+
+**2013 - PythonBrasil[9] (Brasília)**
+
+  * Fernando Massanori
+  * Henrique Bastos
+
+**2014 - PythonBrasil[10] (Porto de Galinhas)**
+
+  * Osvaldo Santana
+
+**2015 - PythonBrasil[11] (São José dos Campos)**
+
+  * Tânia Andrea
+ 
+## Sobre Dorneles Treméa
+
+Gaúcho, colorado, amante de sushi e de suco de maçã, empreendedor, líder de comunidades OSS, desenvolvedor, empreendedor, líder, marido e  pai de duas gurias. 
+
+Déo, como os mais próximos o chamavam, foi fundador da Debian-RS, da Associação Python Brasil, membro da Plone Foundation, Big Kahuna da PythonBrasil[5] e palestrante constante.
+
+Era o presidente da Associação Python Brasil, quando faleceu em um acidente de carro em 10 de fevereiro de 2011 - na época, com 31 anos. 
+ 
+Sempre disposto a ajudar, ele será sempre lembrado por sua disposição de compartilhar conhecimento. Seu legado é o espírito de entrega e dedicação que norteia a existência da Associação Python Brasil.
+ 
+Leia mais sobre Dorneles Treméa em posts e imagens feitos publicados por seus amigos:
+
+* [Sidnei da Silva](http://blog.sidneidasilva.com/2011/02/14/unfinished-life-of-a-sushi-lover/)
+* [Luciano Ramalho](http://blog.ramgarlic.com/2011/06/dorneles-tremea-o-grande-deo.html)
+* [Érico Andrei](http://www.erico.com.br/blog/2011/06/18/no-sleep-for-you)
+* [Nate Aune](https://www.flickr.com/photos/natea/sets/72157625894791457/)


### PR DESCRIPTION
Incluída uma página com a descrição do prêmio, com os ganhadores e uma breve descrição sobre ele, conforme o conteúdo existente atualmente no site da apyb.
