### PR TITLE
Corrigido um erro no README e incluida todas as dependências do SO

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,18 @@ Crie um [virtualenv](https://virtualenv.readthedocs.org/en/latest/) com o nome q
 Provavelmente irá aparecer em seu terminal algo como *(project-name)$*, agora vamos clonar o repositório do projeto:
 
 > git clone git@github.com:pythonbrasil/apyb.git
+
 > cd apyb
 
 Pronto! Você já está na pasta do projeto! Agora vamos instalar os programas necessários (Certifique-se que o virtualenv está ativado):
 
 > pip install -r requirements.txt
 
-Podem ocorrer problemas variados na instalação dos programas, verifique pelo Stackoverflow e pelo Google quais as soluções possíveis. Se o problema persistir, nos informe nas issues.
+Podem ocorrer problemas variados na instalação dos programas, se isso acontecer tente instalar as depêndencias do sistema operacional. No Ubuntu você pode usar o seguinte comando:
+
+> sudo ./install_os_dependencies.sh install
+
+Ou verifique pelo Stackoverflow e pelo Google quais as soluções possíveis. Se o problema persistir, nos informe nas issues.
 
 Legal, agora já instalei todos os programas, vamos fazê-lo rodar em nosso computador?
 

--- a/requirements.apt
+++ b/requirements.apt
@@ -1,7 +1,15 @@
 # listar as dependencias nao python aqui (Ubuntu 14.04 de preferencia)
 python-dev
+build-essential
+
+# lxml dependencies
 libxslt1-dev
 libxml2-dev
-libjpeg-dev
 
-
+## Pillow dependencies
+zlib1g-dev
+libtiff4-dev
+libjpeg8-dev
+libfreetype6-dev
+liblcms1-dev
+libwebp-dev


### PR DESCRIPTION
Corrigi um erro que tinha no README (faltava uma linha em branco), e inclui instruções pra corrigir as dependências do SO para o Ubuntu.

Também inclui todas as dependências sugeridas pelo @luzfcb no requirements.apt testei com uma vm sem nada instalado e apenas com os dois comandos foi possível instalar as dependências do so e do python sem stress :-)
