### PR TITLE
Mudar exibição do link para página do evento

### DIFF
--- a/themes/pybr/templates/eventos.html
+++ b/themes/pybr/templates/eventos.html
@@ -34,7 +34,7 @@
         </h2>
 
         <p>
-          <a href="{{ evento.link }}">Site do Evento</a>
+          <a href="{{ evento.link }}">{{ evento.link }}</a>
         </p>
       </div>
 


### PR DESCRIPTION
Mostrar a URL ao invés de "Site do Evento" é mais claro para o visitante saber onde ele clicar para obter mais informações. Eu demorei um tempinho até perceber essa frase na tela e uma URL é algo que todos já estão acostumados a ver.
