### PR TITLE
Fix olist e-mail link tag

### DIFF
--- a/content/empresas/olist.json
+++ b/content/empresas/olist.json
@@ -6,7 +6,7 @@
     "contatos": [
         {
             "texto": "br@olist.com (Remote friendly)",
-            "link": "br@olist.com"
+            "link": "mailto:br@olist.com"
         }
     ],
     "logo": "images/empresas/olist_logo.jpg",


### PR DESCRIPTION
Sorry for this, the current link redirects to a 404 url.
