### PR TITLE
Incluido python sudeste na listagem de eventos

### DIFF
--- a/content/eventos/2017/python-sudeste.json
+++ b/content/eventos/2017/python-sudeste.json
@@ -1,0 +1,9 @@
+{
+    "nome": "Python Sudeste",
+    "data": "2017-05-05",
+    "cidade": "Rio de Janeiro",
+    "estado": "RJ",
+    "link": "http://pythonsudeste.org/",
+    "latitude": "-22.9120135",
+    "longitude": "-43.2238262"
+}


### PR DESCRIPTION
Includio o evento Python Sudeste 2017 na listagem de eventos, com base nas informações disponíveis em http://pythonsudeste.org/