### PR TITLE
Exibir somente eventos futuros em ordem crescente (mais próximo prime…

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -234,8 +234,10 @@ def import_empresas(path):
     return empresas
 
 # Configurações da página de eventos
+hoje = datetime.date.today()
 EVENTOS = [json.load(open(fname, 'r'), object_hook=date_hook) for fname in glob.glob('content/eventos/*/*.json')]
-EVENTOS = sorted(EVENTOS, key=lambda evento: evento['data'], reverse=True)
+EVENTOS = filter(lambda evento: evento['data'] >= hoje, EVENTOS)
+EVENTOS = sorted(EVENTOS, key=lambda evento: evento['data'], reverse=False)
 
 # Configurações da página de comunidades locais
 COMUNIDADES_LOCAIS = [json.load(open(fname, 'r')) for fname in glob.glob('content/comunidades-locais/*.json')]


### PR DESCRIPTION
Considerando que:
- A página de eventos está exibindo muitos eventos antigos;
- O evento mais próximo está misturado no meio dos outros

Esta alteração remove os eventos passados e coloca o evento mais próximo no topo da lista de eventos para que facilite o visitante encontrar os eventos que vão ocorrer mais próximos.

Seria interessante criar uma página de eventos passados, paginação, filtros, etc. Porém acredito que essa alteração já pode melhorar a usabilidade atual da página.