### PR TITLE
Atualização do link Telegram

### DIFF
--- a/content/comunidades-locais/pythononrio.json
+++ b/content/comunidades-locais/pythononrio.json
@@ -10,7 +10,7 @@
         ],
         [
             "Telegram",
-            "https://telegram.me/joinchat/AONs_ANlfCZRoXOX0QxEzA"
+            "https://t.me/PythonRio"
         ],
         [
             "Twitter",


### PR DESCRIPTION
Atualização do link de invite para o grupo de Telegram do Python on Rio que estava quebrado.