### PR TITLE
Fix logo redirection link and improve content

### DIFF
--- a/content/pages/empresas.md
+++ b/content/pages/empresas.md
@@ -5,7 +5,7 @@ Template: empresas
 
 # Empresas que usam Python
 
-Conheça as empresas espalhados pelo Brasil que utilizam Python.
+Conheça as empresas espalhadas pelo Brasil que utilizam Python.
 
 > Se você quer incluir alguma empresa que usa Python, faça sua contribuição, adicionando-a ao repositório [https://github.com/pythonbrasil/pyBusinesses-BR](https://github.com/pythonbrasil/pyBusinesses-BR). Todos os dados aqui apresentados encontram-se nesse mesmo repositório.
 

--- a/content/pages/introducao.md
+++ b/content/pages/introducao.md
@@ -13,7 +13,7 @@ Existem diversos cursos onlines onde você pode encontrar material. São cursos 
 tipos de variáveis, como escrever funções, etc.
 
 **Devo usar o Interpretador do Python puro?**
-Depende da sua preferência. Ele é uma ferramenta poderosa. Mas uma boa parte dos profissionais usa o interpretador
+Depende da sua preferência. Ele é uma ferramenta poderosa. Mas boa parte de profissionais usa o interpretador
 [*ipython*](http://ipython.org/) pois este contém mais recursos visuais e de auxílio (como colorir as mensagens de erro).
 
 **Que IDE usar?**
@@ -22,7 +22,7 @@ Para quem vem do MATLAB ou R, o [Spyder](https://github.com/spyder-ide/spyder) p
 
 **Aonde eu encontro os módulos para utilizar no meu projeto?**
 Alguns módulos já vem por padrão no Python puro, por exemplo o módulo matemático. Outros, devem ser baixados de um repositório, como é o caso do Django ou Numpy.
-Hoje, mais de 107 mil projetos estão cadastros no [repositório oficial](https://pypi.org/). Caso você não ache o que procura, é super incentivado que você contrua um módulo novo e inclua no repositório!
+Hoje, mais de 107 mil projetos estão cadastros no [repositório oficial](https://pypi.org/). Caso você não ache o que procura, há muito incentivo para que você construa um módulo novo e inclua no repositório!
 
 Se você não tem a menor ideia mesmo de que módulo você precise, dê uma procurada no Google e StackOverflow. De certo alguém já fez algo parecido com o que você precisa!
 

--- a/content/pages/qual-python.md
+++ b/content/pages/qual-python.md
@@ -2,17 +2,17 @@ Title: Qual Python?
 Slug: qual-python
 Template: page
 
-Uma das dúvidas mais recorrentes dentre os iniciantes na linguagem é a respeito da escolha de versão: "Estou começando na linguagem, devo usar python 2 ou python 3?" Para responder a esta pergunta é importante entender o estado atual da linguagem:
+Uma das dúvidas mais recorrentes dentre iniciantes na linguagem é a respeito da escolha de versão: "Estou começando na linguagem, devo usar python 2 ou python 3?" Para responder a esta pergunta é importante entender o estado atual da linguagem:
 
 - Python 2 foi o padrão da linguagem por muito tempo.
 - Python 3 introduziu algumas mudanças que quebraram a compatibilidade com a versão anterior o que criou a nessecidade de se manter duas versões da linguagem.
 - Python 2 receberá atualizações de segurança até 2020 quando seu suporte será descontinuado.
 - Python 3 está constantemente evoluindo e recebendo novas funcionalidades, que não estarão presentes na versão anterior.
 
-Sabendo disso, a recomendação é de dar sempre que possível preferência ao Python 3, por ser o futuro da linguagem e pelo fato de sua versão anterior estar em processo de descontinuação.
+Sabendo disso, a recomendação é dar sempre que possível preferência ao Python 3, por ser o futuro da linguagem e pelo fato de sua versão anterior estar em processo de descontinuação.
 
 Use Python 2 somente quando estiver trabalhando com um software que ainda não foi migrado para Python 3 ou caso precise manter algum sistema legado.
 
-As diferênças entre as versões para quem está começando a aprender a linguagem não são tão grandes ao ponto de você não conseguir alternar entre as duas caso necessário.
+As diferenças entre as versões para quem está começando a aprender a linguagem não são tão grandes ao ponto de você não conseguir alternar entre as duas caso necessário.
 
-Se estiver curioso quanto as mudanças entre as duas versões dê uma olhada neste [link](https://docs.python.org/3.0/whatsnew/3.0.html).
+Se você possuir curiosidade quanto as mudanças entre as duas versões dê uma olhada neste [link](https://docs.python.org/3.0/whatsnew/3.0.html).

--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -84,7 +84,7 @@
             <div class="row">
               <div class="col-12">
                 <div class="header-container">
-                  <a href="{{ SITEURL }}/index">
+                  <a href="{{ SITEURL }}/index.html">
                     <img class="header-logo" src="{{ SITEURL }}/theme/img/site-logo.svg" title="{{ SITENAME }}" alt="{{ SITENAME }}"/>
                   </a>
 


### PR DESCRIPTION
O link anterior era "https://python.org.br/index" e dava: 404 Not Found. Testei por .html ao final e funcionou.