### PR TITLE
Update grupy-go.json

### DIFF
--- a/content/comunidades-locais/grupy-go.json
+++ b/content/comunidades-locais/grupy-go.json
@@ -3,6 +3,18 @@
         [
             "Google Groups",
             "https://groups.google.com/forum/#!forum/grupy-go"
+        ],
+        [
+            "Telegram",
+            "https://t.me/grupygo"
+        ],
+        [
+            "Git Hub",
+            "https://github.com/Grupy-GO"
+        ],
+        [
+            "Facebook",
+            "https://www.facebook.com/groups/grupygo/"
         ]
     ],
     "nome": "Grupo de usu\u00e1rios de Goi\u00e1s",

--- a/content/comunidades-locais/grupy-go.json
+++ b/content/comunidades-locais/grupy-go.json
@@ -9,7 +9,7 @@
             "https://t.me/grupygo"
         ],
         [
-            "Git Hub",
+            "GitHub",
             "https://github.com/Grupy-GO"
         ],
         [


### PR DESCRIPTION
Incluido em wiki/content/comunidades-locais/grupy-go.json os links da telegram, github e facebook da comunidade Grupy-GO