### PR TITLE
Removed broken Telegram communities urls

### DIFF
--- a/content/comunidades-locais/grupy-cps.json
+++ b/content/comunidades-locais/grupy-cps.json
@@ -1,10 +1,6 @@
 {
     "links": [
         [
-            "Telegram",
-	    "https://t.me/joinchat/BCCTWj_O8w9uJKNSoEuaVA"
-        ],
-        [
             "Meetup",
             "https://www.meetup.com/pt-BR/GruPy-Campinas/" 
         ]

--- a/content/comunidades-locais/grupy-pr.json
+++ b/content/comunidades-locais/grupy-pr.json
@@ -15,10 +15,6 @@
         [
             "Slack",
             "http://grupypr.herokuapp.com/"
-        ],
-        [
-            "Telegram",
-            "https://telegram.me/joinchat/AKcLJQkMbfHhN6LOju_s9g"
         ]
     ],
     "nome": "Grupo de usu\u00e1rios do Paran\u00e1",

--- a/content/comunidades-locais/grupy-sanca.json
+++ b/content/comunidades-locais/grupy-sanca.json
@@ -15,10 +15,6 @@
         [
             "Meetup",
             "https://meetup.com/grupy-sanca"
-        ],
-        [
-            "Telegram",
-            "https://t.me/grupysanca"
         ]
     ],
     "nome": "Grupo de usu\u00e1rios Python de S\u00e3o Carlos (SP)",

--- a/content/comunidades-locais/pythononrio.json
+++ b/content/comunidades-locais/pythononrio.json
@@ -9,10 +9,6 @@
             "https://www.facebook.com/pythonrio"
         ],
         [
-            "Telegram",
-            "https://t.me/PythonRio"
-        ],
-        [
             "Twitter",
             "https://twitter.com/pythonrio"
         ],


### PR DESCRIPTION
Removed broken Telegram group urls of `PythonOnRio`, `GruPy-Campinas`, `GruPy-PR`, and `grupy-sanca` in `/comunidades-locais`