### PR TITLE
Atualiza versões do Pelican e Markdown

### DIFF
--- a/pyladies_generator.py
+++ b/pyladies_generator.py
@@ -31,7 +31,7 @@ def scrapping_pyladies():
     com os dados das sedes da Pyladies.
     """
     html = urlopen(PYLADIES_YAML).read()
-    return yaml.load(html)
+    return yaml.safe_load(html)
 
 
 def get_filename(directory, locale):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ ecdsa
 feedgenerator
 jinja2
 lxml
-markdown==2.6.11
+markdown==3.3.6
 markupsafe
 mdx-video
 paramiko
-pelican==3.6
+pelican==4.7.1
 pelican-alias==1.1
 pillow
 pycrypto


### PR DESCRIPTION
## Descrição

As mudanças abaixo foram necessárias para rodar a wiki localmente:

- Atualiza versão do Pelican para mais nova (4.7.1) - desconheço motivo da versão fixada no `requirements.txt`
- Atualiza versão do Markdown para mais nova (3.3.6) - desconheço motivo da versão fixada no `requirements.txt`
- Substitui chamada para `yaml.load` por `yaml.safe_load`.

## Testes
Rodei a wiki localmente, comparei as páginas abaixo com a versão online e todas foram exatamente iguais:
- /
- /introducao
- /wiki (redireciona para https://wiki.python.org.br)
- /comunidades-locais
- /lista-de-discussoes (ambas não funcionam - #265)
- /empresas
- /projetos

Resolve issues: 
- #226