### PR TITLE
Correção de links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ em content/empresas.
 ### Páginas do Inicie-se
 
 1. **Introdução** - Conteúdo em formato markdown no arquivo
-[content/pages/introducao.md](content/pages/qual-python.md).
+[content/pages/introducao.md](content/pages/introducao.md).
 
 1. **Qual python?** - Conteúdo em formato markdown no arquivo
 [content/pages/qual-python.md](content/pages/qual-python.md).

--- a/content/pages/ferramentas.md
+++ b/content/pages/ferramentas.md
@@ -57,7 +57,7 @@ A IDLE vem com o Python. É feita com Tkinter e se você se acostumar pode lhe a
 
 Também desenvolvido pela ActiveState o Komodo-Edit é uma excelente opção de editor, bastante rico em recursos tais como autocomplete, calltips, multi-language file support, syntax coloring, syntax checking, Vi emulation, Emacs key bindings e outros.
 
-### [NetBeans](http://plugins.netbeans.org/plugin/61688/python)
+### [NetBeans](http://nbpython.org/)
 
 Analogamente ao Eclipse, o NetBeans também oferece suporte ao Python através de plugins.
 


### PR DESCRIPTION
Corrigi o link errado no README.md referente à página de introdução e também o link do plugin do NetBeans que estava quebrado.