### PR TITLE
Colocando a conferencia Python Brasil 2023 na capa

### DIFF
--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -84,11 +84,14 @@
             <div class="row">
               <div class="col-12">
                 <div class="header-container">
-                  <a href="{{ SITEURL }}/index.html">
-                    <img class="header-logo" src="{{ SITEURL }}/theme/img/site-logo.svg" title="{{ SITENAME }}" alt="{{ SITENAME }}"/>
+                  <a href="https://2023.pythonbrasil.org.br" target="_blank">
+                    <img class="header-logo" title="Python Brasil 2023" alt="Python Brasil 2023" src="https://2023.pythonbrasil.org.br/theme/img/capa.png">
                   </a>
-
-                  <h2 class="header-subtitle">{{ WELCOME_TEXT }}</h2>
+                  
+                  <h2 class="header-subtitle">DE 30 OUTUBRO A 05 NOVEMBRO DE 2023</h2>
+                  <a class="header-subtitle" href="https://2023.pythonbrasil.org.br/" target="_blank">
+                    Acesse aqui o site da conferência para maiores informações e inscrição
+                  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Colocando a conferencia Python Brasil 2023 na capa.

Está assim:
![image](https://github.com/pythonbrasil/wiki/assets/169837/8c2b1845-aa4d-4c67-bcca-0d228cc260d2)

Clicando no logo ou no link abaixo abre-se o site da conferencia em uma nova aba.

Acidentalmente, passei por uma versao intermediária com o logo da conferência ao lado do logo da comunidade, pode ser uma ideia a ser trabalhalhada também.
![image](https://github.com/pythonbrasil/wiki/assets/169837/66829bfc-8789-4361-be74-f62b4b2e2811)

Caso seja mesclado, passado o evento basta dar revert no commit, ou pode-se colocar este branch em produção também e depois volta para pelican.
