### PR TITLE
Atualizações para rodar no Ubuntu 24.04. Adicionado Dockerfile para facilitar execução

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:24.04
+
+RUN mkdir -p /home/wiki
+COPY . /home/wiki
+WORKDIR /home/wiki
+RUN bash install_os_dependencies.sh install
+RUN python3 -m venv /opt/venv
+RUN /opt/venv/bin/python3 -m pip install -r requirements.txt
+ENV PATH="/opt/venv/bin:$PATH"
+CMD ["/bin/bash", "develop_server.sh", "docker_start"]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Resta então fazer o commit de suas alterações em seu repositório local e env
 
 Mais informações sobre como funciona o Pelican, indicamos o artigo - [http://mindbending.org/pt/instalando-o-pelican](http://mindbending.org/pt/instalando-o-pelican).
 
+Se você quiser gerar o site automaticamente a cada alteração, utilize:
+
+```
+$ make devserver
+```
+
 Caso queira contribuir com o tema é preciso ter o node instalado em sua máquina. Sua instalação é bem direta e pode ser obtida em:
 
 [https://nodejs.org/en/download/](https://nodejs.org/en/download/)
@@ -177,4 +183,21 @@ E caso queira rodar sem o live reload, somente para gerar o css para publicaçã
 
 ```
 $ npm run gulp build
+```
+
+#### Rodando com Docker
+
+Criando a imagem:
+```
+docker build -t wiki .
+```
+
+Rodando:
+```
+docker run --rm -t -i -p 8000:8000 -v .:/home/wiki --name pelican wiki
+```
+
+Parando a imagem:
+```
+docker stop pelican
 ```

--- a/install_os_dependencies.sh
+++ b/install_os_dependencies.sh
@@ -29,12 +29,12 @@ function list_packages(){
 
 function install()
 {
-    list_packages | xargs apt-get --no-upgrade install -y;
+    list_packages | xargs apt --no-upgrade install -y;
 }
 
 function upgrade()
 {
-    list_packages | xargs apt-get install -y;
+    list_packages | xargs apt install -y;
 }
 
 
@@ -52,7 +52,7 @@ function install_or_upgrade()
         exit 1
     else
 
-        apt-get update
+        apt update
 
         # Install the basic compilation dependencies and other required libraries of this project
         if [ "$PARAN" == "install" ]; then
@@ -62,7 +62,7 @@ function install_or_upgrade()
         fi
 
         # cleaning downloaded packages from apt-get cache
-        apt-get clean
+        apt clean
 
         exit 0
     fi

--- a/requirements.apt
+++ b/requirements.apt
@@ -1,5 +1,8 @@
 # listar as dependencias nao python aqui (Ubuntu 14.04 de preferencia)
-python-dev
+python3-dev
+python-is-python3
+python3-pip
+python3-venv
 build-essential
 
 # lxml dependencies
@@ -8,10 +11,10 @@ libxml2-dev
 
 ## Pillow dependencies
 zlib1g-dev
-libtiff4-dev
+libtiff-dev
 libjpeg8-dev
 libfreetype6-dev
-liblcms1-dev
+#liblcms1-dev
 libwebp-dev
 
 #cryptography dependecies

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ paramiko
 pelican==4.7.1
 pelican-alias==1.1
 pillow
-pycrypto
+pycryptodome
 pygments
 python-dateutil
 pytz


### PR DESCRIPTION
Adicionado Dockerfile
Instruções de como usar com docker
Instruções de como rodar o dev server
Atualizações de pacotes para poder instalar no Ubuntu 24.04 LTS
Substituição do pycrypto pelo pycryptodome