### PR TITLE
Adiciona pybr_i18n a gruposonline.md

### DIFF
--- a/content/pages/gruposonline.md
+++ b/content/pages/gruposonline.md
@@ -15,6 +15,7 @@ Sites listados apenas para facilitar serem encontrados.
 - [Data Science Python](https://t.me/datasciencepython)
 - [Django Brasil](https://t.me/djangobrasil)
 - [Flask Brasil](https://t.me/flaskbrasil)
+- [pybr i18n](https://t.me/pybr_i18n)
 
 Diversos grupos e comunidades locais também organizam seus próprios grupos no Telegram.
 [Lista completa das comunidades locais](/comunidades-locais)

--- a/content/pages/gruposonline.md
+++ b/content/pages/gruposonline.md
@@ -15,7 +15,7 @@ Sites listados apenas para facilitar serem encontrados.
 - [Data Science Python](https://t.me/datasciencepython)
 - [Django Brasil](https://t.me/djangobrasil)
 - [Flask Brasil](https://t.me/flaskbrasil)
-- [pybr i18n](https://t.me/pybr_i18n)
+- [Tradução da documentação da documentação do Python e correlatas](https://t.me/pybr_i18n)
 
 Diversos grupos e comunidades locais também organizam seus próprios grupos no Telegram.
 [Lista completa das comunidades locais](/comunidades-locais)


### PR DESCRIPTION
Link para o grupo de discussão sobre tradução de documentação do Python e outras traduções correlatas (ex., Django, Sphinx).