### PR TITLE
Atualiza href referente ao CDC

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -191,7 +191,8 @@ NAVBAR_HOME_LINKS = [
     },
     {
         "title": "Código de Conduta",
-        "href": "cdc",
+        "href": "https://apyb.python.org.br/pythonbrasil/cdc/",
+        "desc": "Código de Conduta da comunidade Python Brasil.",
     },
 ]
 


### PR DESCRIPTION
Atualmente quando você está em alguma página que não seja a principal da wiki, o redirect do CDC não funciona: 
![image](https://github.com/user-attachments/assets/6db17d03-c2c1-4988-b9ca-2ddf259f4c94)

Pensando em corrigir esse problema, estou alterando o conteúdo do `href` para que ele funcione independe da página que a pessoa se encontre:
![image](https://github.com/user-attachments/assets/54c2fab2-8bdb-46ed-a854-657da64cd198)
