### PR TITLE
Substituir 'Python Brasil 2024' por 'Python Brasil 2025' na home page (Issue #321)

### DIFF
--- a/themes/pybr/static/css/custom-colors.css
+++ b/themes/pybr/static/css/custom-colors.css
@@ -1,0 +1,24 @@
+/* Sobrescrevendo as cores do header para usar cinza no estilo do evento */
+.master-wrapper header {
+    background-color: #6c757d !important;
+    background-image: linear-gradient(#495057 10%, #6c757d 90%) !important;
+}
+
+/* Garantindo que o texto continue branco para boa legibilidade */
+.master-wrapper header {
+    color: #fff !important;
+}
+
+.master-wrapper header .header-subtitle {
+    color: #e9ecef !important; /* Cor mais suave que combina com o fundo cinza */
+}
+
+/* Ajustando links para melhor contraste com o fundo cinza */
+.master-wrapper header a {
+    color: #fff !important;
+}
+
+.master-wrapper header a:hover {
+    color: #ffc107 !important;
+    text-decoration: none !important;
+}

--- a/themes/pybr/static/scss/_base.scss
+++ b/themes/pybr/static/scss/_base.scss
@@ -21,10 +21,8 @@ a{
     color: $white;
     padding: 50px 0 60px 0;
     text-align: center;
-
-    /* gradient */
-    background-color: #2b5b84;
-    background-image: linear-gradient(#1e415e 10%,#2b5b84 90%);
+    background-color: #6c757d;
+    background-image: linear-gradient(#495057 10%,#6c757d 90%);
     box-shadow: inset 0 0 50px rgba(0,0,0,0.03),inset 0 0 20px rgba(0,0,0,0.03);
 
     .header-logo {

--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -12,6 +12,8 @@
     <!-- Bootstrap -->
     <link href="{{ SITEURL }}/theme/css/pybr.min.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/css/pygment.css" rel="stylesheet">
+    <!-- Custom colors override -->
+    <link href="{{ SITEURL }}/theme/css/custom-colors.css" rel="stylesheet">
 
     {% block aditional_styles %}
     {% endblock %}

--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -75,13 +75,13 @@
             <div class="row">
               <div class="col-12">
                 <div class="header-container">
-                  <a href="https://2024.pythonbrasil.org.br" target="_blank">
-                    <img class="header-logo" title="Python Brasil 2024" alt="Python Brasil 2024" src="https://2024.pythonbrasil.org.br/theme/images/logo.png">
+                  <a href="https://2025.pythonbrasil.org.br" target="_blank">
+                    <img class="header-logo" title="Python Brasil 2025" alt="Python Brasil 2025 (21-27 de Outubro de 2025)" src="https://2025.pythonbrasil.org.br/images/main.png/@@images/image-2200-805c8bbb1ea72839b86149847d75dce4.png" style="max-width:100%; width:1000px; height:auto;">
                   </a>
                   
-                  <h2 class="header-subtitle">DE 16 A 21 DE OUTUBRO DE 2024</h2>
-                  <a class="header-subtitle" href="https://2024.pythonbrasil.org.br/" target="_blank">
-                    Acesse aqui o site da conferência para maiores informações e inscrição
+                  <!-- Comentando isso, pois as datas ja estao inclusas no logo de 2025. Adicionei as datas como parte do alttext tambem. <h2 class="header-subtitle">DE 21 A 27 DE OUTUBRO DE 2025</h2> -->
+                  <a class="header-subtitle" href="https://2025.pythonbrasil.org.br/" target="_blank">
+                    <h2 class="header-subtitle">Acesse aqui o site da conferência para maiores informações e inscrição!</h2>
                   </a>
                 </div>
               </div>

--- a/themes/pybr/templates/base.html
+++ b/themes/pybr/templates/base.html
@@ -76,7 +76,7 @@
               <div class="col-12">
                 <div class="header-container">
                   <a href="https://2025.pythonbrasil.org.br" target="_blank">
-                    <img class="header-logo" title="Python Brasil 2025" alt="Python Brasil 2025 (21-27 de Outubro de 2025)" src="https://2025.pythonbrasil.org.br/images/main.png/@@images/image-2200-805c8bbb1ea72839b86149847d75dce4.png" style="max-width:100%; width:1000px; height:auto;">
+                    <img class="header-logo" title="Python Brasil 2025" alt="Python Brasil 2025 (21-27 de Outubro de 2025)" src="https://2025.pythonbrasil.org.br/images/main.png/@@images/image-2200-805c8bbb1ea72839b86149847d75dce4.png" style="max-width:100%; width:800px; height:auto;">
                   </a>
                   
                   <!-- Comentando isso, pois as datas ja estao inclusas no logo de 2025. Adicionei as datas como parte do alttext tambem. <h2 class="header-subtitle">DE 21 A 27 DE OUTUBRO DE 2025</h2> -->


### PR DESCRIPTION
**Este Pull Request:**
- Atualiza o `header-logo` para o da Python Brasil 2025, com um tamanha adequado para a página.
- Remove o `header-subtitle` que contém as datas, pois o logo de 2025 já as contém. A linha foi comentada para facilitar em atualizações futuras, caso logos de anos seguintes não contenham as datas.
- Direciona, tanto através do logo como do texto, para a página da conferência.
- Atualiza cores do header: substitui background azul por cinza e ajusta cor do subtítulo de amarelo para branco.

**Screenshots:**
- Antes da mudança das cores
<img width="1375" height="573" alt="image" src="https://github.com/user-attachments/assets/893403f5-e9ee-477a-b255-4cbfec5c81a7" />

- Após as mudanças das cores
<img width="901" height="540" alt="image" src="https://github.com/user-attachments/assets/b3202884-0045-4582-a8c8-587d5bf6c932" />
