### PR TITLE
Atualiza página da Lista de Discussões com informações úteis

### DIFF
--- a/content/pages/lista-de-discussoes.md
+++ b/content/pages/lista-de-discussoes.md
@@ -1,3 +1,52 @@
 Title: Lista de Discussões
 Slug: lista-de-discussoes
-Template: comunidade-google-group
+Template: page
+
+A lista de discussão Python Brasil é um espaço para a comunidade Python brasileira trocar ideias, fazer perguntas e compartilhar conhecimento. Com mais de 12.000 membros, é um dos principais canais de comunicação da comunidade.
+
+## Como Visualizar e Pesquisar Mensagens
+
+Para visualizar todas as mensagens e pesquisar no histórico, acesse:
+
+[https://groups.google.com/g/python-brasil](https://groups.google.com/g/python-brasil)
+
+Todo o conteúdo é público, pesquisável e indexável, tornando a lista uma fonte valiosa de conhecimento acumulado ao longo dos anos.
+
+## Como Participar
+
+### Se Inscrever
+
+1. Acesse [https://groups.google.com/g/python-brasil](https://groups.google.com/g/python-brasil)
+2. Clique em "Participar do grupo"
+3. Configure suas preferências de recebimento de email
+
+### Configurar Emails
+
+Para ajustar como e quando você recebe emails do grupo, acesse:
+
+[https://groups.google.com/g/python-brasil/membership](https://groups.google.com/g/python-brasil/membership)
+
+### Enviar Mensagens
+
+Você pode enviar perguntas e participar das discussões de duas formas:
+
+- Enviando um email para: [python-brasil@googlegroups.com](mailto:python-brasil@googlegroups.com)
+- Usando o botão "Nova Conversa" em [https://groups.google.com/g/python-brasil](https://groups.google.com/g/python-brasil)
+
+### Cancelar Inscrição
+
+Para parar de receber emails do grupo, envie um email para:
+
+[python-brasil+unsubscribe@googlegroups.com](mailto:python-brasil+unsubscribe@googlegroups.com)
+
+## Por Que Google Groups?
+
+O Google Groups oferece vantagens importantes para a comunidade:
+
+- **Conteúdo Público**: Todas as discussões são acessíveis a qualquer pessoa
+- **Pesquisável**: Fácil encontrar respostas para dúvidas já discutidas
+- **Indexável**: Motores de busca podem indexar o conteúdo, aumentando o alcance
+- **Histórico Preservado**: Anos de conhecimento acumulado disponíveis para consulta
+- **Moderação Ativa**: A lista é moderada diariamente para evitar spam e conteúdo inadequado
+
+Diferente de plataformas como WhatsApp, Telegram, Discord ou Facebook, o Google Groups preserva e torna acessível o conhecimento da comunidade a longo prazo.


### PR DESCRIPTION
## Objetivo

Atualizar a página da Lista de Discussões com informações úteis em vez de removê-la completamente, conforme sugestão de @luzfcb.

## Descrição

Este PR atualiza o conteúdo da página `lista-de-discussoes.md` com informações práticas sobre como usar a lista de discussão Python Brasil:

### Conteúdo Incluído:

- **Como Visualizar e Pesquisar Mensagens**: Link direto para o Google Groups com acesso público ao histórico
- **Como Participar**:
  - Se inscrever no grupo
  - Configurar preferências de recebimento de email
  - Enviar mensagens (via email ou interface web)
  - Cancelar inscrição
- **Por Que Google Groups?**: Explica as vantagens da plataforma:
  - Conteúdo público, pesquisável e indexável
  - Histórico preservado a longo prazo
  - Moderação ativa diária
  - Superior a outras plataformas para preservação de conhecimento

### Contexto:

A lista possui mais de 12.000 membros e é moderada diariamente por @luzfcb para evitar spam e conteúdo inadequado. O Google Groups oferece vantagens importantes sobre plataformas como WhatsApp, Telegram, Discord ou Facebook, principalmente por preservar e tornar acessível o conhecimento da comunidade a longo prazo.

---

Segue sugestão de @luzfcb em https://github.com/pythonbrasil/wiki/pull/324#issuecomment-2268769619

Relacionado a #265