### PR TITLE
Adiciona script de testes para validacao do site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo '   make serve [PORT=8000]           serve site at http://localhost:8000'
 	@echo '   make devserver [PORT=8000]       start/restart develop_server.sh    '
 	@echo '   make stopserver                  stop local server                  '
+	@echo '   make test                        run tests on generated site        '
 	@echo '   make github                      upload the web site via gh-pages   '
 	@echo '                                                                       '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
@@ -82,4 +83,8 @@ ping:
 	curl -Is http://www.google.com/webmasters/tools/ping?sitemap=http://pythonbrasil.github.io/wiki/sitemap.xml | grep "200 OK" || echo "Erro pinging Google"
 	curl -Is http://www.bing.com/webmaster/ping.aspx?siteMap=http://pythonbrasil.github.io/wiki/sitemap.xml | grep "200 OK" || echo "Erro pinging Bing"
 
-.PHONY: html help clean regenerate serve devserver publish github
+test:
+	@echo "Executando testes..."
+	$(PY) test_site.py
+
+.PHONY: html help clean regenerate serve devserver publish github test

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,31 @@
+# Testando o Site
+
+Script simples para validar o site antes de fazer PR.
+
+## Uso
+
+```bash
+# Gere o site
+make html
+
+# Execute os testes
+make test
+```
+
+## O que verifica
+
+- JSON exposto no HTML (erro de parser)
+- Estrutura basica do HTML
+- Links 404 (opcional com --check-links)
+
+## Verificar links
+
+```bash
+# Terminal 1
+make serve
+
+# Terminal 2
+python test_site.py --check-links
+```
+
+Requer: `pip install requests`

--- a/test_site.py
+++ b/test_site.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Script de teste simples para validar o site antes de aceitar PRs.
+
+Validações:
+- Verifica presença de JSON na página (indicando erro de parser)
+- Valida estrutura básica do HTML
+- Opcionalmente verifica links 404 com requests
+
+Uso: python test_site.py
+"""
+
+import sys
+import re
+from pathlib import Path
+
+
+def check_json_in_html(filepath):
+    """Verifica se há JSON exposto no HTML (indicando erro de parser)."""
+    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read()
+
+        # Procura padrões de JSON fora de tags script
+        if re.search(r'(?<!<script[^>]*>)\{["\'][a-z_]+["\']\s*:\s*["\']', content):
+            return ["JSON exposto detectado"]
+    return []
+
+
+def check_html_structure(filepath):
+    """Valida estrutura básica do HTML."""
+    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read().lower()
+
+        # Ignora redirects
+        if 'http-equiv="refresh"' in content:
+            return []
+
+        issues = []
+        if '<html' not in content:
+            issues.append("Tag <html> ausente")
+        if '<body' not in content:
+            issues.append("Tag <body> ausente")
+        return issues
+
+
+def check_links_404():
+    """Verifica links 404 (requer requests)."""
+    try:
+        import requests
+    except ImportError:
+        print("Instale 'requests' para verificar links: pip install requests")
+        return True
+
+    try:
+        r = requests.get('http://localhost:8000', timeout=5)
+        # Extrai links básicos com regex
+        links = re.findall(r'href=["\']([^"\']+)["\']', r.text)
+
+        errors = []
+        for link in set(links[:20]):  # Limita a 20
+            if link.startswith(('http', '/', '#')) and not link.startswith('#'):
+                url = link if link.startswith('http') else f'http://localhost:8000{link}'
+                try:
+                    resp = requests.head(url, timeout=3, allow_redirects=True)
+                    if resp.status_code == 404:
+                        errors.append(f"404: {url}")
+                except:
+                    pass
+
+        if errors:
+            print("\nLinks 404 encontrados:")
+            for e in errors:
+                print(f"  {e}")
+            return False
+        print("\nLinks verificados OK")
+        return True
+    except:
+        print("\nServidor nao disponivel. Execute 'make serve' primeiro.")
+        return True
+
+
+def main():
+    print("=" * 50)
+    print("Teste do Site - Python Brasil")
+    print("=" * 50)
+
+    output_dir = Path('output')
+    if not output_dir.exists():
+        print("\nDiretorio 'output' nao existe. Execute 'make html'")
+        sys.exit(1)
+
+    html_files = list(output_dir.rglob('*.html'))
+    print(f"\n{len(html_files)} arquivos HTML encontrados\n")
+
+    errors, warnings = [], []
+
+    for html_file in html_files:
+        path = html_file.relative_to(output_dir)
+
+        # Verifica JSON exposto
+        json_issues = check_json_in_html(html_file)
+        for issue in json_issues:
+            warnings.append(f"AVISO: {path}: {issue}")
+
+        # Verifica estrutura
+        html_issues = check_html_structure(html_file)
+        for issue in html_issues:
+            errors.append(f"ERRO: {path}: {issue}")
+
+    if errors:
+        print("ERROS:")
+        for e in errors[:10]:
+            print(f"  {e}")
+        if len(errors) > 10:
+            print(f"  ... +{len(errors)-10} erros")
+
+    if warnings:
+        print("\nAVISOS:")
+        for w in warnings[:5]:
+            print(f"  {w}")
+        if len(warnings) > 5:
+            print(f"  ... +{len(warnings)-5} avisos")
+
+    if not errors and not warnings:
+        print("Nenhum problema encontrado!")
+
+    # Verifica links se --check-links
+    links_ok = True
+    if '--check-links' in sys.argv:
+        links_ok = check_links_404()
+
+    print("\n" + "=" * 50)
+    if not errors and links_ok:
+        print("TESTES OK")
+        print("=" * 50)
+        sys.exit(0)
+    else:
+        print("TESTES FALHARAM")
+        print("=" * 50)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Implementa script de testes automatizado simples para validar o site estatico gerado pelo Pelican antes de aceitar PRs.

## Validações Incluidas

- **JSON exposto no HTML**: Detecta quando o parser do Pelican falha e expõe JSON no HTML
- **Estrutura básica do HTML**: Verifica presença de tags `<html>` e `<body>` em todas as paginas
- **Links 404 (opcional)**: Com a flag `--check-links`, verifica se ha links quebrados no site

## Uso

```bash
# Gerar o site e executar testes
make html
make test

# Verificar links (requer servidor rodando)
make serve  # Terminal 1
python test_site.py --check-links  # Terminal 2
```

## Detalhes Técnicos

- Script simples (~145 linhas) sem dependências externas (exceto `requests` para verificacao opcional de links)
- Usa regex para detectar padrões problemáticos
- Retorna exit code 0 (sucesso) ou 1 (falha) para integração com CI

Resolve #218